### PR TITLE
Point docker-compose to the correct container image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   kasm:
     build: .
-    image: kasm-ltc-workspace
+    image: ghcr.io/capsulecorplab/kasm-ltc-workspace:main
     ports:
       - "6901:6901"
     environment:


### PR DESCRIPTION
docker-compose.yml was previously not pointing to the correct image via ghcr causing `docker-compose pull && docker-compose up` to fail. This PR addresses this issue by updating docker-compose.yml with the correct image.