### PR TITLE
Update git ppa to use correct version for Ubuntu 20.04.1

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -65,7 +65,7 @@
   tags: install_git_keychain
 
   vars:
-    git_version: "2.36.1"
+    git_version: "2.37.1"
     git_version_to_install: "1:{{ git_version }}-0ppa1~ubuntu20.04.1"
     keychain_version: "2.8.5"
     keychain_version_to_install: "{{ keychain_version }}-1"


### PR DESCRIPTION
Fixes a build issue with `docker-compose build` and the project's CI/CD. playbook.yaml pointed to the incorrect version of git (2.36.1) for Ubuntu 20.04.1. According to launchpad, the correct version is 2.37.1: https://launchpad.net/~git-core/+archive/ubuntu/ppa 

![image](https://user-images.githubusercontent.com/6404980/180668251-8284ac53-09e1-4d4e-975c-0fa89e7ddf0f.png)

